### PR TITLE
Update OperationInterface methods to support familyId

### DIFF
--- a/src/ListBuilder/Chain.php
+++ b/src/ListBuilder/Chain.php
@@ -4,6 +4,9 @@ namespace CascadeEnergy\DistributedOperations\ListBuilder;
 
 class Chain implements OperationListBuilderInterface
 {
+    /** @var string */
+    private $familyId;
+
     /** @var OperationListBuilderInterface[] */
     private $operationListBuilderList = [];
 
@@ -26,5 +29,10 @@ class Chain implements OperationListBuilderInterface
         }
 
         return $operationList;
+    }
+
+    public function setFamilyId($familyId)
+    {
+        $this->familyId = $familyId;
     }
 }

--- a/src/ListBuilder/OperationListBuilderInterface.php
+++ b/src/ListBuilder/OperationListBuilderInterface.php
@@ -5,4 +5,6 @@ namespace CascadeEnergy\DistributedOperations\ListBuilder;
 interface OperationListBuilderInterface
 {
     public function buildOperationList($batchId, array $options = [], array $preconditions = []);
+
+    public function setFamilyId($familyId);
 }

--- a/src/ListBuilder/Pipeline.php
+++ b/src/ListBuilder/Pipeline.php
@@ -4,6 +4,9 @@ namespace CascadeEnergy\DistributedOperations\ListBuilder;
 
 class Pipeline implements OperationListBuilderInterface
 {
+    /** @var string */
+    private $familyId;
+
     /** @var OperationListBuilderInterface[] */
     private $operationListBuilderList = [];
 
@@ -21,5 +24,10 @@ class Pipeline implements OperationListBuilderInterface
         }
 
         return $operationList;
+    }
+
+    public function setFamilyId($familyId)
+    {
+        $this->familyId = $familyId;
     }
 }

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -25,6 +25,9 @@ class Operation implements OperationInterface
     private $disposition = self::DISPOSITION_NONE;
 
     /** @var string */
+    private $familyId;
+
+    /** @var string */
     private $id;
 
     /** @var array */
@@ -108,6 +111,16 @@ class Operation implements OperationInterface
     public function setDisposition($disposition)
     {
         $this->disposition = $disposition;
+    }
+
+    public function getFamilyId()
+    {
+        return $this->familyId;
+    }
+
+    public function setFamilyId($familyId)
+    {
+        $this->familyId = $familyId;
     }
 
     public function getId()

--- a/src/OperationInterface.php
+++ b/src/OperationInterface.php
@@ -16,6 +16,9 @@ interface OperationInterface
     public function getDisposition();
     public function setDisposition($disposition);
 
+    public function getFamilyId();
+    public function setFamilyId($familyId);
+
     public function getId();
     public function setId($id);
 


### PR DESCRIPTION
- Interface  updates to `OperationInterface` and `OperationListBuilderInterface` to support setting of `familyId`

fixes #1 
